### PR TITLE
Update code to SMAPI 2.4

### DIFF
--- a/CustomFarm.cs
+++ b/CustomFarm.cs
@@ -131,7 +131,7 @@ namespace CustomFarmTypes
         public override SObject getFish(float millisecondsAfterNibble, int bait, int waterDepth, SFarmer who, double baitPotency, string locationName = null)
         {
             var fishingRod = who.CurrentTool as FishingRod;
-            var bobber = Mod.instance.Helper.Reflection.GetPrivateValue<Vector2>(fishingRod, "bobber");
+            var bobber = Mod.instance.Helper.Reflection.GetField<Vector2>(fishingRod, "bobber").GetValue();
             Point bobberTile = new Point((int)bobber.X / Game1.tileSize, (int)bobber.Y / Game1.tileSize);
 
             int poolFrom = -1;

--- a/CustomFarmTypes.csproj
+++ b/CustomFarmTypes.csproj
@@ -11,8 +11,6 @@
     <AssemblyName>CustomFarmTypes</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -45,15 +43,6 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <Choose>
-    <When Condition="$(OS) == 'Windows_NT'">
-      <ItemGroup>
-        <Reference Include="Microsoft.Xna.Framework.Xact, Version=4.0.0.0, Culture=neutral, PublicKeyToken=842cf8be1de50553, processorArchitecture=x86">
-          <Private>false</Private>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
   <ItemGroup>
     <Compile Include="NewCharacterCustomizeMenu.cs" />
     <Compile Include="CustomFarm.cs" />
@@ -99,31 +88,17 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.1.5.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Target Name="AfterBuild">
-    <PropertyGroup>
-      <ModPath>$(GamePath)\Mods\$(TargetName)</ModPath>
-    </PropertyGroup>
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll" DestinationFolder="$(ModPath)" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).pdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).pdb')" />
-    <Copy SourceFiles="$(TargetDir)\$(TargetName).dll.mdb" DestinationFolder="$(ModPath)" Condition="Exists('$(TargetDir)\$(TargetName).dll.mdb')" />
-    <Copy SourceFiles="$(ProjectDir)manifest.json" DestinationFolder="$(ModPath)" />
+  <Target Name="DeployFarmTypes" BeforeTargets="AfterBuild">
     <ItemGroup>
       <ResourceFiles Include="$(ProjectDir)res\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(ResourceFiles)" DestinationFiles="@(ResourceFiles->'$(ModPath)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(ResourceFiles)" DestinationFiles="@(ResourceFiles->'$(GamePath)\Mods\CustomFarmTypes\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 </Project>

--- a/CustomFarmTypes.csproj
+++ b/CustomFarmTypes.csproj
@@ -99,6 +99,6 @@
     <ItemGroup>
       <ResourceFiles Include="$(ProjectDir)res\**\*.*" />
     </ItemGroup>
-    <Copy SourceFiles="@(ResourceFiles)" DestinationFiles="@(ResourceFiles->'$(GamePath)\Mods\CustomFarmTypes\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(ResourceFiles)" DestinationFiles="@(ResourceFiles->'$(TargetDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
   </Target>
 </Project>

--- a/Mod.cs
+++ b/Mod.cs
@@ -3,10 +3,6 @@ using System.IO;
 using StardewModdingAPI;
 using StardewModdingAPI.Events;
 using StardewValley;
-using Microsoft.Xna.Framework.Graphics;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Input;
-using SFarmer = StardewValley.Farmer;
 using System.Collections.Generic;
 using StardewValley.Menus;
 using StardewValley.Locations;
@@ -27,6 +23,8 @@ namespace CustomFarmTypes
             instance = this;
             
             SaveEvents.AfterLoad += afterLoad;
+            SaveEvents.BeforeCreate += beforeSave;
+            SaveEvents.AfterCreate += afterSave;
             SaveEvents.BeforeSave += beforeSave;
             SaveEvents.AfterSave += afterSave;
             GameEvents.UpdateTick += onUpdate;

--- a/Mod.cs
+++ b/Mod.cs
@@ -24,7 +24,6 @@ namespace CustomFarmTypes
 
         public override void Entry(IModHelper helper)
         {
-            base.Entry(helper);
             instance = this;
             
             SaveEvents.AfterLoad += afterLoad;
@@ -188,10 +187,10 @@ namespace CustomFarmTypes
                     Log.debug("Found vanilla new game window, replacing with our own.");
 
                     var oldMenu = (CharacterCustomization)TitleMenu.subMenu;
-                    var shirts = Helper.Reflection.GetPrivateValue<List<int>>(oldMenu, "shirtOptions");
-                    var hairs = Helper.Reflection.GetPrivateValue<List<int>>(oldMenu, "hairStyleOptions");
-                    var accessories = Helper.Reflection.GetPrivateValue<List<int>>(oldMenu, "accessoryOptions");
-                    var wizard = Helper.Reflection.GetPrivateValue<bool>(oldMenu, "wizardSource");
+                    var shirts = Helper.Reflection.GetField<List<int>>(oldMenu, "shirtOptions").GetValue();
+                    var hairs = Helper.Reflection.GetField<List<int>>(oldMenu, "hairStyleOptions").GetValue();
+                    var accessories = Helper.Reflection.GetField<List<int>>(oldMenu, "accessoryOptions").GetValue();
+                    var wizard = Helper.Reflection.GetField<bool>(oldMenu, "wizardSource").GetValue();
                     var newMenu = new NewCharacterCustomizeMenu(shirts, hairs, accessories, wizard);
 
                     TitleMenu.subMenu = newMenu;

--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,10 @@
 {
   "Name": "Custom Farm Types",
   "Author": "spacechase0",
-  "Version": {
-    "MajorVersion": 1,
-    "MinorVersion": 1,
-    "PatchVersion": 2,
-    "Build": ""
-  },
+  "Version": "1.1.2",
   "Description": "Allow custom farm types.",
   "UniqueID": "spacechase0.CustomFarmTypes",
-  "PerSaveConfigs": false,
-  "EntryDll": "CustomFarmTypes.dll"
+  "EntryDll": "CustomFarmTypes.dll",
+  "MinimumApiVersion": "2.0",
+  "UpdateKeys": [ "chucklefish:4705" ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,6 @@
   "Description": "Allow custom farm types.",
   "UniqueID": "spacechase0.CustomFarmTypes",
   "EntryDll": "CustomFarmTypes.dll",
-  "MinimumApiVersion": "2.0",
+  "MinimumApiVersion": "2.3",
   "UpdateKeys": [ "chucklefish:4705" ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Custom Farm Types",
   "Author": "spacechase0",
-  "Version": "1.1.2",
+  "Version": "1.1.3",
   "Description": "Allow custom farm types.",
   "UniqueID": "spacechase0.CustomFarmTypes",
   "EntryDll": "CustomFarmTypes.dll",

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,6 @@
   "Description": "Allow custom farm types.",
   "UniqueID": "spacechase0.CustomFarmTypes",
   "EntryDll": "CustomFarmTypes.dll",
-  "MinimumApiVersion": "2.3",
+  "MinimumApiVersion": "2.4",
   "UpdateKeys": [ "chucklefish:4705" ]
 }

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="1.5.0" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
This pull request...
* Fixes an issue where players can't start a custom farm in SMAPI 2.1+ (they always get the standard farm).
* Enables [automatic update checks](https://stardewvalleywiki.com/Modding:SMAPI_APIs#Update_checks).
* Updates the `manifest.json` format.
* Updates the mod build package to the latest version.  
  _The new version simplifies the project file, and automatically deploys the mod to your `Mods` folder automatically and creates a release zip._

If these changes look fine, can you deploy [CustomFarmTypes 1.1.3.zip](https://github.com/spacechase0/CustomFarmTypes/files/1650160/CustomFarmTypes.1.1.3.zip) to the [Nexus Mods page](https://www.nexusmods.com/stardewvalley/mods/1140) and [Chucklefish mod page](https://community.playstarbound.com/resources/custom-farm-types.4705/)?

~~**This requires the upcoming SMAPI 2.4, so it shouldn't be released immediately.**~~