### PR TITLE
Update for SMAPI 3.0 and partially for Stardew Valley 1.3.32

### DIFF
--- a/CustomFarm.cs
+++ b/CustomFarm.cs
@@ -5,11 +5,7 @@ using StardewValley.Tools;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using xTile;
-using SFarmer = StardewValley.Farmer;
 using SObject = StardewValley.Object;
-using StardewModdingAPI;
-using System.Xml.Serialization;
 
 namespace CustomFarmTypes
 {
@@ -17,8 +13,7 @@ namespace CustomFarmTypes
     {
         private static void swap<T>(ref T lhs, ref T rhs)
         {
-            T temp;
-            temp = lhs;
+            T temp = lhs;
             lhs = rhs;
             rhs = temp;
         }
@@ -86,12 +81,12 @@ namespace CustomFarmTypes
                         if (entry != null)
                         {
                             var obj = entry.getObject();
-                            obj.canBeSetDown = false;
-                            if (obj.parentSheetIndex < 75 || obj.parentSheetIndex > 77)
-                                obj.isSpawnedObject = true;
-                            obj.tileLocation = new Vector2(area.Area.x + Game1.random.Next(area.Area.w), area.Area.y + Game1.random.Next(area.Area.h));
+                            obj.CanBeSetDown = false;
+                            if (obj.ParentSheetIndex < 75 || obj.ParentSheetIndex > 77)
+                                obj.IsSpawnedObject = true;
+                            obj.TileLocation = new Vector2(area.Area.x + Game1.random.Next(area.Area.w), area.Area.y + Game1.random.Next(area.Area.h));
                             obj.getBoundingBox(obj.TileLocation);
-                            dropObject(obj, new Vector2(obj.tileLocation.X * Game1.tileSize, obj.tileLocation.Y * Game1.tileSize), Game1.viewport, true, null);
+                            dropObject(obj, new Vector2(obj.TileLocation.X * Game1.tileSize, obj.TileLocation.Y * Game1.tileSize), Game1.viewport, true, null);
                             if ( !entry.SkipChanceDecrease)
                                 d *= type.Behavior.ForageableSpawnChanceMultiplier;
                             continue;
@@ -103,13 +98,13 @@ namespace CustomFarmTypes
 
             if (type.Behavior.SpecialWeedCount > 0 && !Game1.IsWinter)
             {
-                if (this.objects.Count > 0)
+                if (this.Objects.Any())
                 {
                     for (int index = 0; index < type.Behavior.SpecialWeedCount; ++index)
                     {
                         SObject @object = this.objects.ElementAt(Game1.random.Next(this.objects.Count)).Value;
                         if (@object.name.Equals("Weeds"))
-                            @object.parentSheetIndex = 792 + Utility.getSeasonNumber(Game1.currentSeason);
+                            @object.ParentSheetIndex = 792 + Utility.getSeasonNumber(Game1.currentSeason);
                     }
                 }
             }
@@ -128,7 +123,7 @@ namespace CustomFarmTypes
             return -1;
         }
 
-        public override SObject getFish(float millisecondsAfterNibble, int bait, int waterDepth, SFarmer who, double baitPotency, string locationName = null)
+        public override SObject getFish(float millisecondsAfterNibble, int bait, int waterDepth, Farmer who, double baitPotency, string locationName = null)
         {
             var fishingRod = who.CurrentTool as FishingRod;
             var bobber = Mod.instance.Helper.Reflection.GetField<Vector2>(fishingRod, "bobber").GetValue();
@@ -151,8 +146,8 @@ namespace CustomFarmTypes
             int parentSheetIndex = -1;
             Dictionary<string, string> dictionary1 = Game1.content.Load<Dictionary<string, string>>("Data\\Locations");
             bool flag1 = false;
-            string key = locationName == null ? this.name : locationName;
-            if (this.name.Equals("WitchSwamp") && !Game1.player.mailReceived.Contains("henchmanGone") && (Game1.random.NextDouble() < 0.25 && !Game1.player.hasItemInInventory(308, 1, 0)))
+            string key = locationName ?? this.Name;
+            if (this.Name.Equals("WitchSwamp") && !Game1.player.mailReceived.Contains("henchmanGone") && (Game1.random.NextDouble() < 0.25 && !Game1.player.hasItemInInventory(308, 1, 0)))
                 return new SObject(308, 1, false, -1, 0);
             if (dictionary1.ContainsKey(key))
             {
@@ -228,7 +223,7 @@ namespace CustomFarmTypes
             Random random = new Random(timeOfDay + (int)Game1.uniqueIDForThisGame / 2 + (int)Game1.stats.DaysPlayed);
 
             // Fishing
-            if (this.fishSplashPoint.Equals(Point.Zero) && random.NextDouble() < type.Behavior.FishingSplashChance)
+            if (this.fishSplashPoint.Value.Equals(Point.Zero) && random.NextDouble() < type.Behavior.FishingSplashChance)
             {
                 for (int index = 0; index < 2; ++index)
                 {
@@ -240,7 +235,7 @@ namespace CustomFarmTypes
                         {
                             if (Game1.player.currentLocation.Equals((object)this))
                                 Game1.playSound("waterSlosh");
-                            this.fishSplashPoint = point;
+                            this.fishSplashPoint.Value = point;
                             this.fishSplashAnimation = new TemporaryAnimatedSprite(51, new Vector2((float)(point.X * Game1.tileSize), (float)(point.Y * Game1.tileSize)), Color.White, 10, false, 80f, 999999, -1, -1f, -1, 0);
                             break;
                         }
@@ -267,7 +262,7 @@ namespace CustomFarmTypes
                         if (doesTileHavePropertyNoNull((int)pos.X, (int)pos.Y, "Type", "Back").Equals("Dirt") && this.isTileLocationTotallyClearAndPlaceable(pos))
                         {
                             var obj = entry.getObject();
-                            obj.tileLocation = pos;
+                            obj.TileLocation = pos;
                             obj.getBoundingBox(obj.TileLocation);
                             objects.Add(pos, obj);
                         }

--- a/CustomFarmTypes.csproj
+++ b/CustomFarmTypes.csproj
@@ -52,29 +52,71 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="res\FarmTypes\Everything\map.xnb" />
-    <None Include="res\FarmTypes\Everything\type.json" />
-    <None Include="res\FarmTypes\Everything_NoDebris\map.xnb" />
-    <None Include="res\FarmTypes\Everything_NoDebris\type.json" />
-    <None Include="res\FarmTypes\Forest_NoDebris\map.xnb" />
-    <None Include="res\FarmTypes\Mountains_NoDebris\map.xnb" />
-    <None Include="res\FarmTypes\Riverlands_NoDebris\map.xnb" />
-    <None Include="res\FarmTypes\Standard_NoDebris\map.xnb" />
-    <None Include="res\FarmTypes\Wilderness_NoDebris\map.xnb" />
-    <None Include="res\FarmTypes\Wilderness_NoDebris\type.json" />
-    <None Include="res\FarmTypes\Mountains_NoDebris\type.json" />
-    <None Include="res\FarmTypes\Riverlands_NoDebris\type.json" />
-    <None Include="res\FarmTypes\Standard_NoDebris\type.json" />
-    <None Include="res\FarmTypes\Forest_NoDebris\type.json" />
+    <None Include="res\FarmTypes\Everything\map.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Everything\type.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Everything_NoDebris\map.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Everything_NoDebris\type.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Forest_NoDebris\map.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Mountains_NoDebris\map.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Riverlands_NoDebris\map.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Standard_NoDebris\map.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Wilderness_NoDebris\map.xnb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Wilderness_NoDebris\type.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Mountains_NoDebris\type.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Riverlands_NoDebris\type.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Standard_NoDebris\type.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="res\FarmTypes\Forest_NoDebris\type.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="res\FarmTypes\Everything\icon.png" />
-    <Content Include="res\FarmTypes\Everything_NoDebris\icon.png" />
-    <Content Include="res\FarmTypes\Forest_NoDebris\icon.png" />
-    <Content Include="res\FarmTypes\Mountains_NoDebris\icon.png" />
-    <Content Include="res\FarmTypes\Riverlands_NoDebris\icon.png" />
-    <Content Include="res\FarmTypes\Standard_NoDebris\icon.png" />
-    <Content Include="res\FarmTypes\Wilderness_NoDebris\icon.png" />
+    <Content Include="res\FarmTypes\Everything\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="res\FarmTypes\Everything_NoDebris\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="res\FarmTypes\Forest_NoDebris\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="res\FarmTypes\Mountains_NoDebris\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="res\FarmTypes\Riverlands_NoDebris\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="res\FarmTypes\Standard_NoDebris\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="res\FarmTypes\Wilderness_NoDebris\icon.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SpaceCore\SpaceCore.csproj">
@@ -88,10 +130,4 @@
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.0.2" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="DeployFarmTypes" BeforeTargets="AfterBuild">
-    <ItemGroup>
-      <ResourceFiles Include="$(ProjectDir)res\**\*.*" />
-    </ItemGroup>
-    <Copy SourceFiles="@(ResourceFiles)" DestinationFiles="@(ResourceFiles->'$(TargetDir)\%(RecursiveDir)%(Filename)%(Extension)')" />
-  </Target>
 </Project>

--- a/CustomFarmTypes.csproj
+++ b/CustomFarmTypes.csproj
@@ -126,8 +126,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CustomFarmTypes.csproj
+++ b/CustomFarmTypes.csproj
@@ -30,10 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -56,7 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
-    <None Include="packages.config" />
     <None Include="res\FarmTypes\Everything\map.xnb" />
     <None Include="res\FarmTypes\Everything\type.json" />
     <None Include="res\FarmTypes\Everything_NoDebris\map.xnb" />
@@ -88,14 +83,11 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="8.0.3" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.0.2" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.0.2\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
-  </Target>
   <Target Name="DeployFarmTypes" BeforeTargets="AfterBuild">
     <ItemGroup>
       <ResourceFiles Include="$(ProjectDir)res\**\*.*" />

--- a/FarmType.cs
+++ b/FarmType.cs
@@ -65,26 +65,28 @@ namespace CustomFarmTypes
                         return SubEntries.Last().getObject();
                     }
 
-                    return new SObject(new Vector2(), ObjectID, InitialStack) { minutesUntilReady = OreHealth };
+                    return new SObject(new Vector2(), ObjectID, InitialStack) { MinutesUntilReady = OreHealth };
                 }
 
                 public static SpawnBehaviorEntry Forageable(double chance, int obj)
                 {
-                    SpawnBehaviorEntry s = new SpawnBehaviorEntry();
-                    s.Chance = chance;
-                    s.ObjectID = obj;
-                    return s;
+                    return new SpawnBehaviorEntry
+                    {
+                        Chance = chance,
+                        ObjectID = obj
+                    };
                 }
 
                 public static SpawnBehaviorEntry Ore(double chance, int levelReq, int obj, int health)
                 {
-                    SpawnBehaviorEntry s = new SpawnBehaviorEntry();
-                    s.Chance = chance;
-                    s.MiningLevelRequirement = levelReq;
-                    s.ObjectID = obj;
-                    s.InitialStack = 10;
-                    s.OreHealth = health;
-                    return s;
+                    return new SpawnBehaviorEntry
+                    {
+                        Chance = chance,
+                        MiningLevelRequirement = levelReq,
+                        ObjectID = obj,
+                        InitialStack = 10,
+                        OreHealth = health
+                    };
                 }
 
                 public static SpawnBehaviorEntry chooseEntry(List<SpawnBehaviorEntry> entries)
@@ -101,7 +103,7 @@ namespace CustomFarmTypes
                         if (Game1.random.NextDouble() <= entry.Chance)
                             ret = entry;
                     }
-                    return ret == null ? entries.Last() : ret;
+                    return ret ?? entries.Last();
                 }
             }
 
@@ -136,38 +138,42 @@ namespace CustomFarmTypes
 
                 public static FishPoolEntry FinalPreset(string loc)
                 {
-                    FishPoolEntry fish = new FishPoolEntry();
-                    fish.Chance = 1.0;
-                    fish.OnlyTryIfNoneSelectedYet = true;
-                    fish.LocationPreset = loc;
-                    return fish;
+                    return new FishPoolEntry
+                    {
+                        Chance = 1.0,
+                        OnlyTryIfNoneSelectedYet = true,
+                        LocationPreset = loc
+                    };
                 }
 
                 public static FishPoolEntry Preset(double chance, string loc, double luck = 0)
                 {
-                    FishPoolEntry fish = new FishPoolEntry();
-                    fish.Chance = chance;
-                    fish.LuckFactor = luck;
-                    fish.LocationPreset = loc;
-                    return fish;
+                    return new FishPoolEntry
+                    {
+                        Chance = chance,
+                        LuckFactor = luck,
+                        LocationPreset = loc
+                    };
                 }
 
                 public static FishPoolEntry FinalObject(int obj)
                 {
-                    FishPoolEntry fish = new FishPoolEntry();
-                    fish.Chance = 1.0;
-                    fish.OnlyTryIfNoneSelectedYet = true;
-                    fish.ObjectID = obj;
-                    return fish;
+                    return new FishPoolEntry
+                    {
+                        Chance = 1.0,
+                        OnlyTryIfNoneSelectedYet = true,
+                        ObjectID = obj
+                    };
                 }
 
                 public static FishPoolEntry Object(double chance, int obj, double luck = 0)
                 {
-                    FishPoolEntry fish = new FishPoolEntry();
-                    fish.Chance = chance;
-                    fish.LuckFactor = luck;
-                    fish.ObjectID = obj;
-                    return fish;
+                    return new FishPoolEntry
+                    {
+                        Chance = chance,
+                        LuckFactor = luck,
+                        ObjectID = obj
+                    };
                 }
 
                 public SObject getObject()

--- a/Mod.cs
+++ b/Mod.cs
@@ -12,8 +12,6 @@ namespace CustomFarmTypes
 {
     public class Mod : StardewModdingAPI.Mod
     {
-        public const int MY_FARM_TYPE = 6;
-
         public static Mod instance;
         public static SaveData Data = new SaveData();
 
@@ -91,7 +89,7 @@ namespace CustomFarmTypes
         {
             if (!(Game1.year == 1 && Game1.currentSeason == "spring" && Game1.dayOfMonth == 0))
             {
-                Log.debug("Loading save data... " + Game1.year + " " + Game1.currentSeason + " " + Game1.dayOfMonth);
+                Log.debug($"Loading save data... {Game1.year} {Game1.currentSeason} {Game1.dayOfMonth}");
                 Data = Helper.Data.ReadSaveData<SaveData>("custom-farm-types");
                 if (Data == null)
                 {
@@ -106,7 +104,7 @@ namespace CustomFarmTypes
                 if ( loc.GetType() != typeof( Farm ) )
                     continue;
 
-                Log.info("Custom farm type " + entry.Value + " for " + entry.Key);
+                Log.info($"Custom farm type {entry.Value} for {entry.Key}");
                 FarmType type = FarmType.getType(entry.Value);
                 if (type == null)
                 {
@@ -114,7 +112,7 @@ namespace CustomFarmTypes
                     return;
                 }
 
-                var newFarm = new CustomFarm(type, loc.name);
+                var newFarm = new CustomFarm(type, loc.Name);
                 if (Game1.year == 1 && Game1.currentSeason == "spring" && Game1.dayOfMonth == 1)
                 {
                     Log.debug("First day? from load");
@@ -140,9 +138,9 @@ namespace CustomFarmTypes
                 GameLocation loc = Game1.getLocationFromName(entry.Key);
                 if (loc.GetType() == typeof(CustomFarm))
                 {
-                    Log.debug("Putting vanilla farm over " + entry.Key + "=" + entry.Value);
+                    Log.debug($"Putting vanilla farm over {entry.Key}={entry.Value}");
                     var farm = loc as CustomFarm;
-                    Farm newFarm = new Farm(Helper.Content.Load<xTile.Map>("Maps\\Farm", ContentSource.GameContent), loc.name);
+                    Farm newFarm = new Farm("Maps\\Farm", loc.Name);
                     CustomFarm.swapFarms(farm, newFarm);
                     Game1.locations.Remove(farm);
                     Game1.locations.Add(newFarm);
@@ -252,7 +250,7 @@ namespace CustomFarmTypes
             {
                 var furn = new Furniture(fp.FurnitureID, fp.Position, fp.Rotations);
                 if (fp.HeldFurnitureID != -1)
-                    furn.heldObject = new Furniture(fp.HeldFurnitureID, fp.Position);
+                    furn.heldObject.Value = new Furniture(fp.HeldFurnitureID, fp.Position);
                 Log.debug("Furniture: " + fp.FurnitureID + "(" + fp.HeldFurnitureID + ") @ " + fp.Position + " " + fp.Rotations );
                 house.furniture.Add(furn);
             }
@@ -267,7 +265,7 @@ namespace CustomFarmTypes
                 foreach (var e in type.Farmhouse.Giftbox.Contents)
                 {
                     Log.debug("Giftbox item: " + e.ObjectID + " x " + e.Amount);
-                    items.Add(new SObject(e.ObjectID, e.Amount, false, -1, 0));
+                    items.Add(new SObject(e.ObjectID, e.Amount));
                 }
                 Log.debug("Giftbox position: " + type.Farmhouse.Giftbox.Position);
                 var giftbox = new Chest(0, items, type.Farmhouse.Giftbox.Position, items.Count == 1);

--- a/Mod.cs
+++ b/Mod.cs
@@ -90,7 +90,7 @@ namespace CustomFarmTypes
             if (!(Game1.year == 1 && Game1.currentSeason == "spring" && Game1.dayOfMonth == 0))
             {
                 Log.debug("Loading save data... " + Game1.year + " " + Game1.currentSeason + " " + Game1.dayOfMonth);
-                Data = Helper.ReadJsonFile<SaveData>(Path.Combine(Constants.CurrentSavePath, "custom-farm-type.json"));
+                Data = Helper.Data.ReadSaveData<SaveData>("custom-farm-types");
                 if (Data == null)
                 {
                     Data = new SaveData();
@@ -143,12 +143,13 @@ namespace CustomFarmTypes
                     Game1.locations.Add(newFarm);
                 }
             }
+
+            Helper.Data.WriteSaveData("custom-farm-types", Data);
         }
 
         private void afterSave(object sender, EventArgs args)
         {
-            Log.info("Saving, putting custom farms back...");
-            Helper.WriteJsonFile(Path.Combine(Constants.CurrentSavePath, "custom-farm-type.json"), Data);
+            Log.info("Saved, putting custom farms back...");
             foreach (var entry in Data.FarmTypes)
             {
                 GameLocation loc = Game1.getLocationFromName(entry.Key);

--- a/MyRectangle.cs
+++ b/MyRectangle.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.Xna.Framework;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CustomFarmTypes
 {

--- a/SaveData.cs
+++ b/SaveData.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace CustomFarmTypes
 {

--- a/TypeFixes.cs
+++ b/TypeFixes.cs
@@ -18,13 +18,13 @@ namespace CustomFarmTypes
     {
         internal static void fix()
         {
-            Hijack.hijack(typeof(   Game1).GetMethod("performTenMinuteClockUpdate", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance),
-                          typeof(NewGame1).GetMethod("performTenMinuteClockUpdate", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));
-            Hijack.hijack(typeof(   FarmAnimal).GetMethod("updateWhenCurrentLocation", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance),
-                          typeof(NewFarmAnimal).GetMethod("updateWhenCurrentLocation", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));
+            Hijack.hijack(typeof(   Game1).GetMethod(nameof(Game1.performTenMinuteClockUpdate), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance),
+                          typeof(NewGame1).GetMethod(nameof(NewGame1.performTenMinuteClockUpdate), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));
+            Hijack.hijack(typeof(   FarmAnimal).GetMethod(nameof(FarmAnimal.updateWhenCurrentLocation), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance),
+                          typeof(NewFarmAnimal).GetMethod(nameof(NewFarmAnimal.updateWhenCurrentLocation), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));
             
-            Hijack.hijack(typeof(   BlueprintsMenu).GetMethod("receiveLeftClick", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance),
-                          typeof(NewBlueprintsMenu).GetMethod("receiveLeftClick", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));
+            Hijack.hijack(typeof(   BlueprintsMenu).GetMethod(nameof(BlueprintsMenu.receiveLeftClick), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance),
+                          typeof(NewBlueprintsMenu).GetMethod(nameof(NewBlueprintsMenu.receiveLeftClick), BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));
             // This is causing problems, and doesn't appear to be used?
             /*Hijack.hijack(typeof(   CataloguePage).GetMethod("receiveLeftClick", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance),
                           typeof(NewCataloguePage).GetMethod("receiveLeftClick", BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance));

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "Description": "Allow custom farm types.",
   "UniqueID": "spacechase0.CustomFarmTypes",
   "EntryDll": "CustomFarmTypes.dll",
-  "MinimumApiVersion": "2.4",
+  "MinimumApiVersion": "2.9.0",
   "UpdateKeys": [ "chucklefish:4705" ],
   "Dependencies": [
     {

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.0.2" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
This pull request...

* Updates the code for compatibility with the upcoming SMAPI 3.0 (still compatible with current versions of SMAPI) and partially updates it for Stardew Valley 1.3.32 (parts which need a rewrite were left as-is).
* Updates the code to store data in the save file using the new data API.
* Updates the mod build package and simplifies the build settings.
* Migrates to the new package reference format.

I realise Custom Farm Types is discontinued, so I don't expect you to release an update. I just updated it since I'm in the code anyway to update your other mods. :)